### PR TITLE
chore: upgrade .NET version to 10.0 across projects and Dockerfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "9.0.x"
+        - name: Setup .NET
+          uses: actions/setup-dotnet@v4
+          with:
+            dotnet-version: "10.0.x"
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-        - name: Setup .NET
-          uses: actions/setup-dotnet@v4
-          with:
-            dotnet-version: "10.0.x"
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/simulator/SkyNet.Simulator.Cli/SkyNet.Simulator.Cli.csproj
+++ b/simulator/SkyNet.Simulator.Cli/SkyNet.Simulator.Cli.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/simulator/SkyNet.Simulator.Contracts/SkyNet.Simulator.Contracts.csproj
+++ b/simulator/SkyNet.Simulator.Contracts/SkyNet.Simulator.Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/simulator/SkyNet.Simulator.Core/SkyNet.Simulator.Core.csproj
+++ b/simulator/SkyNet.Simulator.Core/SkyNet.Simulator.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/simulator/SkyNet.Simulator.Daemon/Dockerfile
+++ b/simulator/SkyNet.Simulator.Daemon/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 COPY NuGet.Config ./
@@ -16,7 +16,7 @@ COPY . .
 
 RUN dotnet publish simulator/SkyNet.Simulator.Daemon/SkyNet.Simulator.Daemon.csproj -c Release -o /app/publish /p:UseAppHost=false
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
 ENV urls=http://0.0.0.0:5070

--- a/simulator/SkyNet.Simulator.Daemon/Dockerfile.dev
+++ b/simulator/SkyNet.Simulator.Daemon/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 # Install VS Code .NET debugger (vsdbg)
 RUN apt-get update \

--- a/simulator/SkyNet.Simulator.Daemon/SkyNet.Simulator.Daemon.csproj
+++ b/simulator/SkyNet.Simulator.Daemon/SkyNet.Simulator.Daemon.csproj
@@ -10,7 +10,7 @@
 	</ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/simulator/SkyNet.Simulator.Dashboard/Dockerfile
+++ b/simulator/SkyNet.Simulator.Dashboard/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 COPY NuGet.Config ./

--- a/simulator/SkyNet.Simulator.Dashboard/Dockerfile.dev
+++ b/simulator/SkyNet.Simulator.Dashboard/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 # Install VS Code .NET debugger (vsdbg)
 RUN apt-get update \

--- a/simulator/SkyNet.Simulator.Dashboard/SkyNet.Simulator.Dashboard.csproj
+++ b/simulator/SkyNet.Simulator.Dashboard/SkyNet.Simulator.Dashboard.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.11" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
   </ItemGroup>
 

--- a/simulator/SkyNet.Simulator.Tests/SkyNet.Simulator.Tests.csproj
+++ b/simulator/SkyNet.Simulator.Tests/SkyNet.Simulator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/simulator/SkyNet.Simulator.Tests/TankTransferSystemTests.cs
+++ b/simulator/SkyNet.Simulator.Tests/TankTransferSystemTests.cs
@@ -6,6 +6,23 @@ namespace SkyNet.Simulator.Tests;
 
 public class TankTransferSystemTests
 {
+	private static (ParameterStore parameters, TankTransferSystem system, SimulationRunner runner) CreateRig()
+	{
+		var parameters = new ParameterStore();
+		var system = new TankTransferSystem(parameters);
+		var runner = new SimulationRunner(system);
+
+		parameters.Set(TankTransferSystem.ParameterKeys.SourceTankWeightLb.Name, 50000);
+		parameters.Set(TankTransferSystem.ParameterKeys.DestinationTankWeightLb.Name, 0);
+		parameters.Set(TankTransferSystem.ParameterKeys.DestinationTankCapacityLb.Name, 500000);
+		parameters.Set(TankTransferSystem.ParameterKeys.AirlockSpeedCommandHz.Name, 15);
+		parameters.Set(TankTransferSystem.ParameterKeys.BlowlinePressureCommandPsi.Name, 15);
+		parameters.Set(TankTransferSystem.ParameterKeys.BlowerEnable.Name, 1);
+		parameters.Set(TankTransferSystem.ParameterKeys.AirlockEnable.Name, 1);
+
+		return (parameters, system, runner);
+	}
+
 	private static (double srcLb, double dstLb, double rateLbPerSec, double blowerPercent, double pPsi) Run(
 		double airlockHz,
 		double blowlinePsi,
@@ -98,5 +115,80 @@ public class TankTransferSystemTests
 		Assert.True(finalDst <= 20 + 1e-6);
 		Assert.True(finalSrc >= 30 - 1e-6); // with dest capped at 20, at least 30 lb must remain
 		Assert.True(isFull >= 0.999);
+	}
+
+	[Fact]
+	public void BlowerDisable_DecaysPressureToZero_AndStopsTransfer()
+	{
+		var (parameters, system, runner) = CreateRig();
+
+		for (var i = 0; i < 360; i++)
+		{
+			runner.StepOnce();
+		}
+
+		var pressureBeforeDisable = system.Signals.Get("BlowlinePressurePsi");
+		var destinationBeforeDisable = system.Signals.Get("DestinationTankWeightLb");
+		var blowerRunningBeforeDisable = system.Signals.Get("BlowerRunning");
+
+		parameters.Set(TankTransferSystem.ParameterKeys.BlowerEnable.Name, 0);
+
+		for (var i = 0; i < 240; i++)
+		{
+			runner.StepOnce();
+		}
+
+		var pressureAfterDisable = system.Signals.Get("BlowlinePressurePsi");
+		var blowerLoadAfterDisable = system.Signals.Get("BlowerMotorPercentFla");
+		var transferRateAfterDisable = system.Signals.Get("TransferRateLbPerSec");
+		var destinationAfterDisable = system.Signals.Get("DestinationTankWeightLb");
+		var blowerRunningAfterDisable = system.Signals.Get("BlowerRunning");
+
+		Assert.True(blowerRunningBeforeDisable >= 0.999);
+		Assert.True(blowerRunningAfterDisable <= 1e-9);
+		Assert.True(pressureBeforeDisable > 1.0);
+		Assert.True(pressureAfterDisable < 0.5);
+		Assert.True(blowerLoadAfterDisable <= 1e-9);
+		Assert.True(transferRateAfterDisable <= 1e-9);
+		Assert.True(Math.Abs(destinationAfterDisable - destinationBeforeDisable) <= 1e-6);
+	}
+
+	[Fact]
+	public void AirlockDisable_DecaysSpeedToZero_StopsTransfer_AndKeepsLowPressureFloor()
+	{
+		var (parameters, system, runner) = CreateRig();
+
+		for (var i = 0; i < 360; i++)
+		{
+			runner.StepOnce();
+		}
+
+		var speedBeforeDisable = system.Signals.Get("AirlockSpeedHz");
+		var pressureBeforeDisable = system.Signals.Get("BlowlinePressurePsi");
+		var destinationBeforeDisable = system.Signals.Get("DestinationTankWeightLb");
+		var airlockRunningBeforeDisable = system.Signals.Get("AirlockRunning");
+
+		parameters.Set(TankTransferSystem.ParameterKeys.AirlockEnable.Name, 0);
+
+		for (var i = 0; i < 240; i++)
+		{
+			runner.StepOnce();
+		}
+
+		var speedAfterDisable = system.Signals.Get("AirlockSpeedHz");
+		var pressureAfterDisable = system.Signals.Get("BlowlinePressurePsi");
+		var transferRateAfterDisable = system.Signals.Get("TransferRateLbPerSec");
+		var destinationAfterDisable = system.Signals.Get("DestinationTankWeightLb");
+		var airlockRunningAfterDisable = system.Signals.Get("AirlockRunning");
+
+		Assert.True(airlockRunningBeforeDisable >= 0.999);
+		Assert.True(airlockRunningAfterDisable <= 1e-9);
+		Assert.True(speedBeforeDisable > 1.0);
+		Assert.True(speedAfterDisable < 0.2);
+		Assert.True(transferRateAfterDisable <= 1e-9);
+		Assert.True(Math.Abs(destinationAfterDisable - destinationBeforeDisable) <= 1e-6);
+		Assert.True(pressureBeforeDisable > 1.0);
+		Assert.True(pressureAfterDisable > 0.2);
+		Assert.True(pressureAfterDisable < 1.5);
 	}
 }


### PR DESCRIPTION
Issue: #8 
This pull request upgrades the entire SkyNet Simulator solution from .NET 9.0 to .NET 10.0 and updates related dependencies and Dockerfiles accordingly. It also adds new tests to improve coverage of the tank transfer system's behavior when disabling the blower and airlock subsystems.

The most important changes are:

**.NET 10.0 Upgrade Across Solution:**
* Updated all project files (`.csproj`) in the solution to target `net10.0` instead of `net9.0` for `SkyNet.Simulator.Cli`, `SkyNet.Simulator.Contracts`, `SkyNet.Simulator.Core`, `SkyNet.Simulator.Daemon`, `SkyNet.Simulator.Dashboard`, and `SkyNet.Simulator.Tests` projects. [[1]](diffhunk://#diff-232e6182a61285107c12949351e72b8b798078350c243f6d868d57145870b12dL9-R9) [[2]](diffhunk://#diff-533a0b4cb3df71202b67d218a91d532e5e396a39900dbe9007be4499363a7636L4-R4) [[3]](diffhunk://#diff-dc446fb529405d62abc94d134887776f6ea7ad58075efdfffa6734ff2141ab57L13-R13) [[4]](diffhunk://#diff-1af5f989e6a2bc22520611d5535f003318c454feef51a3fda740b474dc64f132L4-R11) [[5]](diffhunk://#diff-b6feb8623b92e7678682d23296f314dfd6dc7f7f345e56b210c82c863cbb4bd7L4-R4)
* Updated GitHub Actions workflow to use `dotnet-version: "10.0.x"` for CI builds.

**Dependency and Dockerfile Updates:**
* Updated all Dockerfiles and development Dockerfiles to use .NET 10.0 base images instead of 9.0. [[1]](diffhunk://#diff-05af261e6384c09d0a168a4227d916f671799d2823ee27dc289b92ba03e0e861L3-R3) [[2]](diffhunk://#diff-05af261e6384c09d0a168a4227d916f671799d2823ee27dc289b92ba03e0e861L19-R19) [[3]](diffhunk://#diff-9c1c40809f8513dc8b1a9c80b045f85123a849f03c19f957bb43ec9cc94a9812L3-R3) [[4]](diffhunk://#diff-8dd5c5f0261fa88aeb8e3ff16e6fc7796d33b166727c9f202817997358a186e8L3-R3)
* Updated Blazor WebAssembly package references in `SkyNet.Simulator.Dashboard` to version `10.0.2`.

**Testing Improvements:**
* Added new tests in `TankTransferSystemTests` to verify correct system behavior when disabling the blower and airlock, ensuring proper decay of pressure/speed and halting of transfer. [[1]](diffhunk://#diff-38ba5f2bbe6c6c61e1ac388b132972a2581266a338102695131b6a4b8c5496a0R9-R25) [[2]](diffhunk://#diff-38ba5f2bbe6c6c61e1ac388b132972a2581266a338102695131b6a4b8c5496a0R119-R193)

These changes ensure the codebase is up-to-date with the latest .NET LTS version and improve reliability by extending test coverage for critical system behaviors.